### PR TITLE
Remove components barrel export file (index.js)

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,0 @@
-// Main components barrel export
-export * from './auth';


### PR DESCRIPTION
Deleted src/components/index.js which previously re-exported the auth component. This may be part of a refactor or cleanup to simplify component imports

it was not necessary